### PR TITLE
Fix shop wizard error on items with characters like & in auto pricer

### DIFF
--- a/Autobuyer/src/inject/autopricer.js
+++ b/Autobuyer/src/inject/autopricer.js
@@ -581,7 +581,7 @@ async function RunAutoPricer(){
                         })
                     } else {
                         try{
-                            window.location.href = `https://www.neopets.com/shops/wizard.phtml?string=${autoPricingList[currentPricingIndex].Name}`;
+                            window.location.href = `https://www.neopets.com/shops/wizard.phtml?string=${encodeURIComponent(autoPricingList[currentPricingIndex].Name)}`;
                         } catch {
                             window.location.reload();
                         }

--- a/Autobuyer/src/inject/kq.js
+++ b/Autobuyer/src/inject/kq.js
@@ -69,7 +69,7 @@ getSTART_AUTOKQ_PROCESS(function(isActive){
                 
 
                 // Launching the SW;
-                window.location.href = `https://www.neopets.com/shops/wizard.phtml?string=${itemArray[0]}`;
+                window.location.href = `https://www.neopets.com/shops/wizard.phtml?string=${encodeURIComponent(itemArray[0])}`;
                 setAUTOKQ_STATUS(`Ingredients Read! Initializing SW for ${itemArray.length} items...`);
             });
         });

--- a/Autobuyer/src/inject/userbuyer.js
+++ b/Autobuyer/src/inject/userbuyer.js
@@ -14,7 +14,7 @@ getSTART_AUTOKQ_PROCESS(async function(isActive){
 
             // If there are ingredients to search left, then go to the SW after purchase;
             if(ingredients.length > 0){
-                window.location.href = `https://www.neopets.com/shops/wizard.phtml?string=${ingredients[0]}`;
+                window.location.href = `https://www.neopets.com/shops/wizard.phtml?string=${encodeURIComponent(ingredients[0])}`;
             } else { // If not, it means the quest can be completed;
                 setSUBMIT_AUTOKQ_PROCESS(true);
                 setAUTOKQ_STATUS("Ingredients Bought! Preparing for Quest Completion...");
@@ -28,7 +28,7 @@ getSTART_AUTOKQ_PROCESS(async function(isActive){
 
         // If the ingredient has been taken off the purchase list, then proceed;
         if(!ingredients.includes(itemName)){
-            window.location.href = `https://www.neopets.com/shops/wizard.phtml?string=${ingredients[0]}`;
+            window.location.href = `https://www.neopets.com/shops/wizard.phtml?string=${encodeURIComponent(ingredients[0])}`;
         }
 
         if (buyLink) {

--- a/Autobuyer/src/options/Autopricer/autopricer.js
+++ b/Autobuyer/src/options/Autopricer/autopricer.js
@@ -355,7 +355,7 @@ function StartAutoPricer(){
 
             // Function to create a new tab if swTab is null
             if(isTurbo){
-                chrome.tabs.create({ url: `https://www.neopets.com/shops/wizard.phtml?string=${autoPricingList[0].Name}`, active: true });
+                chrome.tabs.create({ url: `https://www.neopets.com/shops/wizard.phtml?string=${encodeURIComponent(autoPricingList[0].Name)}`, active: true });
             } else {
                 chrome.tabs.create({ url: 'https://www.neopets.com/shops/wizard.phtml', active: true });
             }


### PR DESCRIPTION
For items like `Peanut Butter & Jelly Waffle Sandwich` characters after & will be cut off and cause auto pricer to be stuck